### PR TITLE
Fix links and colors in dark mode

### DIFF
--- a/dark.html
+++ b/dark.html
@@ -25,7 +25,7 @@
     }
 
     body {
-        filter: invert(90%);
+        filter: hue-rotate(180deg) invert(90%);
     }
 
     #container {

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
         <link rel="stylesheet" href="main.css">
         <link rel="stylesheet" href="dark-toggle.css">
         <link rel="icon" type="image/png" href="bitcointreasuries.org-favicon.png">
+        <base target="_parent" />
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40834364-9"></script>
 <script>
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
Since I load the `index.html` in an iframe the links weren't working properly. 