### PR TITLE
Add issue template for public company submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/public-company-submission.md
+++ b/.github/ISSUE_TEMPLATE/public-company-submission.md
@@ -1,0 +1,16 @@
+---
+name: Public company submission
+about: See requirements at https://bitcointreasuries.org/add
+title: 'Add public company [NAME]'
+labels: ''
+assignees: ''
+
+---
+
+- Name: e.g. Square, Inc.
+- Exchange symbol: e.g. NYSE:SQ
+- Quote link: e.g. https://www.nyse.com/quote/XNYS:SQ
+- Basis price: $XXX
+- Market cap: $XXX
+- Total BTC: XXX BTC
+- Direct link to latest financial report


### PR DESCRIPTION
This change adds a GitHub issue template for submitting a public company based on the makeshift template at #43. This more integrated approach will help ensure that submitters actually follow the template guidelines, avoiding the kind of rejection and rework seen in #46 and #47.

To see this issue template in action, try opening an issue on my fork of this repository at https://github.com/cbeams/bitcointreasuries.org/issues. When clicking 'New Issue' there, you'll see that you're presented with the option to choose the 'Public company submission' template. Should this PR be merged, the same workflow will show up here.

If this approach is preferred, additional issue templates can be added for each of the different types of companies listed at https://bitcointreasuries.org/add.html.

See [the GitHub documentation](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository) for more details on issue templates.